### PR TITLE
Update rdoc redirect

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,8 +1,8 @@
 <IfModule mod_rewrite.c>
     RewriteEngine On
 
-    RewriteRule ^rdoc/(.*).html(.*)$ https://www.rubydoc.info/github/gosu/gosu/master/$1$2 [R=301,L]
-    RewriteRule ^rdoc(/?)$ https://www.rubydoc.info/github/gosu/gosu/master/ [R=301,L]
+    RewriteRule ^rdoc/(.*).html(.*)$ https://www.rubydoc.info/gems/gosu/$1$2 [R=301,L]
+    RewriteRule ^rdoc(/?)$ https://www.rubydoc.info/gems/gosu/ [R=301,L]
 
     RewriteCond %{HTTPS} off
     # First rewrite to HTTPS:


### PR DESCRIPTION
to use the more current https://rubydoc.info/gems/gosu instead of the glitchy https://rubydoc.info/github/gosu/gosu/master